### PR TITLE
Zappa CLI: enabling 'minify' in the config file.

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2701,6 +2701,7 @@ class ZappaCLI:
                 use_precompiled_packages=self.stage_config.get(
                     "use_precompiled_packages", True
                 ),
+                minify=self.stage_config.get('minify', True),
                 exclude=self.stage_config.get("exclude", []),
                 exclude_glob=self.stage_config.get("exclude_glob", []),
                 disable_progress=self.disable_progress,
@@ -2716,6 +2717,7 @@ class ZappaCLI:
                 venv=self.zappa.create_handler_venv(),
                 handler_file=handler_file,
                 slim_handler=True,
+                minify=self.stage_config.get('minify', True),
                 exclude=exclude,
                 exclude_glob=self.stage_config.get("exclude_glob", []),
                 output=output,
@@ -2734,6 +2736,7 @@ class ZappaCLI:
                 use_precompiled_packages=self.stage_config.get(
                     "use_precompiled_packages", True
                 ),
+                minify=self.stage_config.get('minify', True),
                 exclude=exclude,
                 exclude_glob=self.stage_config.get("exclude_glob", []),
                 output=output,


### PR DESCRIPTION
## Description
Enables `minify` setting in the `zappa_setings.json` that packs to ZIP **all** the files without any exclusions (even if they are explicitly provided). Use `minify` with care:

* remove all large files from the source
* remove all unnecessary libs from your virtual environment (`venv`)



## GitHub Issues
Partial fix (rather workaround) for https://github.com/zappa/Zappa/issues/643 : as fas for now we can't get rid of `concurrent` exclusion, and this REALLY prevents from using the legitimate modules and submodules / directories called `concurrent`, this allows the `concurrent` directories in principle, and is used with care no significant growth of ZIP expected.

