### PR TITLE
Package: Remove "concurrent" from exclude.

### DIFF
--- a/zappa/cli.py
+++ b/zappa/cli.py
@@ -2436,7 +2436,7 @@ class ZappaCLI:
                 disable_progress=self.disable_progress,
             )
         else:
-            exclude = self.stage_config.get("exclude", ["boto3", "dateutil", "botocore", "s3transfer", "concurrent"])
+            exclude = self.stage_config.get("exclude", ["boto3", "dateutil", "botocore", "s3transfer"])
 
             # Create a single zip that has the handler and application
             self.zip_path = self.zappa.create_lambda_zip(

--- a/zappa/core.py
+++ b/zappa/core.py
@@ -586,8 +586,8 @@ class Zappa:
 
         # Make sure that 'concurrent' is always forbidden.
         # https://github.com/Miserlou/Zappa/issues/827
-        if "concurrent" not in exclude:
-            exclude.append("concurrent")
+        # if "concurrent" not in exclude:
+        #     exclude.append("concurrent")
 
         def splitpath(path):
             parts = []


### PR DESCRIPTION
Since Zappa is a stupid project that exclude subfolders that not related to the build-in packages in Lambda, we need to remove concurrent from the default exclude list.

